### PR TITLE
SSE-3276: Updated waf ruleset to allow these rules.

### DIFF
--- a/waf/waf.template.yml
+++ b/waf/waf.template.yml
@@ -19,7 +19,6 @@ Parameters:
   Application:
     Description: "The application that the waf should protect."
     Type: "String"
-    Default: dev
     MaxLength : 22
     AllowedPattern: "^[a-zA-Z0-9-]+$"
 
@@ -62,6 +61,9 @@ Resources:
             ManagedRuleGroupStatement:
               VendorName: AWS
               Name: AWSManagedRulesCommonRuleSet
+              ExcludedRules:
+                - Name: EC2MetaDataSSRF_QUERYARGUMENTS
+                - Name: EC2MetaDataSSRF_BODY
           OverrideAction:
             !If
             - IsProdLikeEnvironment


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/SSE-3276

These two rules block legitimate requests within the application. Until the application can be updated to resolve these issues these rules should be counting only.