### PR TITLE
SSE-3228: Ignoring TestDefaultSecurityGroupAudit policy findings from alerts.

### DIFF
--- a/monitoring/security-findings/security-findings.template.yml
+++ b/monitoring/security-findings/security-findings.template.yml
@@ -33,9 +33,18 @@ Resources:
             RecordState: [ "ACTIVE" ]
             Severity:
               Label: [ "HIGH", "CRITICAL" ]
+            Workflow:
+              Status: [ "NEW" ]
             Title:
               - anything-but:
                   - "1.14 Ensure hardware MFA is enabled for the root user"
+            Resources:
+              Details:
+                Other:
+                  fmsPolicyName:
+                    - anything-but:
+                        - "TestDefaultSecurityGroupAudit" # See https://govukverify.atlassian.net/browse/SSE-3288
+
       State: !If [ IsAlerting, "ENABLED", "DISABLED" ]
       Targets:
         - Arn: !GetAtt EventRuleLogsGroup.Arn


### PR DESCRIPTION
My feeling on this ticket is that we’re using the dev-platform vpc template, so if they’re happy with the default egress being enabled then it’s not for us to make this change.

@Rafal Surowiec I think best if we ignore the findings in security hub from TestDefaultSecurityGroupAudit policy for the time being, with the knowledge that this is policy is not a permanent fixture (see comments on https://govukverify.atlassian.net/browse/SSE-3288)