### PR TITLE
SSE-3210 Add network AllowRule to enable product page -> Jira API

### DIFF
--- a/aws-account-config/network/network.template.yml
+++ b/aws-account-config/network/network.template.yml
@@ -74,6 +74,9 @@ Resources:
           pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:".service-now.com";
           endswith; msg:"Pass TLS to service-now"; flow:established; rev:1; sid:2007;)
 
+          pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:".atlassian.net";
+          endswith; msg:"Pass TLS to atlassian"; flow:established; rev:1; sid:2008;)
+
   AccessLogsBucket:
     # checkov:skip=CKV_AWS_18:Ensure the S3 bucket has access logging enabled
     # checkov:skip=CKV_AWS_21:Ensure the S3 bucket has versioning enabled


### PR DESCRIPTION
SSE-3210 allows the product page registration form to communicate directly with the Jira API (an atlassian product).

We're experiencing the integration working fine locally but failing acceptance testing on preview.

We suspect this is due to exposure to network rules. Indeed here we seem to be allowing sucati allow rules for other major integrations but the atlassian domain is not allowed.

This adds the root atlassian domain, allowing a 443 HTTPS connection, following the example of previous it gives it an SID of 2008, my logic being take the previous highest number and add 1.