### PR TITLE
LS-2023 Verify domain ownership for google console via DNS record

### DIFF
--- a/domain/domain.template.yml
+++ b/domain/domain.template.yml
@@ -123,6 +123,12 @@ Resources:
           Type: CNAME
           TTL: 172800
 
+        - Name: !Ref Domain
+          Type: TXT
+          ResourceRecords:
+          - "\"google-site-verification=29R-qq6QJ-1kNjZl5HDOxwbQkPihE3Xs7nbRwa9FdGY\"" # Added for Huw's Google Search Console setup.
+          TTL: 3600 # 1hr
+
         # Docs delegated to di-documentation #203073707786
         - Name: !Sub docs.${Domain}
           ResourceRecords: [


### PR DESCRIPTION
This repo manages the DNS records for https://sign-in.service.gov.uk. We want to bring both this domain and our main https://account.gov.uk domain under the watchful eye of google search console.

It'll allow us to both survey our entire estate as seen by google and do things like downrake or adjust SEO for elements that are civil servant facing vs end user facing.

This becomes especially important when we consider things like contact forms where high volumes of users with support enquiries could easily end up on the "wrong" One Login support form is SEO is misconfigured.

This commit adds a new RecordSet to the existing AWS::Route53::RecordSetGroup It provides a TXT record that should append:

```
google-site-verification=29R-qq6QJ-1kNjZl5HDOxwbQkPihE3Xs7nbRwa9FdGY
```

to the DNS config for for sign-in.sevice.gov.uk, proving we own the domain by making that edit.

The code has been generated against Huw Diprose's search console account, and may need to be shared more broadly after. If you find yourself locked out of this, you'll either need to generate your own code and replace this line or go find Huw.

This attempt notes recent work in the main domains repo here: https://github.com/govuk-one-login/domains/pull/84

It's not a direct copy paste noting lines 90-94 of comments here:

```
  # The GOV.UK nameservers for service.gov.uk route traffic for
  # sign-in.service.gov.uk and all its subdomains to its zone apex.
  # The zone apex then routes requests to the appropriate targets.
  # GOV.UK DNS https://github.com/alphagov/govuk-dns-tf/blob/main/zones/service.gov.uk.yaml
  # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html
```

And the pre-existing convention that DNS records are added as RecordSets appended to an AWS:Route53:RecordSetGroup rather than as a RecordSet AWS resource in it's own right.