### PR TITLE
LS-2023 - Add Google Console CNAME validation

### DIFF
--- a/domain/domain.template.yml
+++ b/domain/domain.template.yml
@@ -123,11 +123,17 @@ Resources:
           Type: CNAME
           TTL: 172800
 
+          # See commit message TXT validation failed, trying CNAME below, candidate for removal on future PR
         - Name: !Ref Domain
           Type: TXT
           ResourceRecords:
           - "\"google-site-verification=29R-qq6QJ-1kNjZl5HDOxwbQkPihE3Xs7nbRwa9FdGY\"" # Added for Huw's Google Search Console setup.
           TTL: 3600 # 1hr
+
+        - Name: zvjmfu36uwrs
+          ResourceRecords: [ gv-hbxx5flro3bd42.dv.googlehosted.com ]
+          Type: CNAME
+          TTL: 172800 # 48h
 
         # Docs delegated to di-documentation #203073707786
         - Name: !Sub docs.${Domain}


### PR DESCRIPTION
This is a suppliment and follow on to:
LS-2023 Verify domain ownership for google console via DNS record (#36)

TXT validation hasn't worked, it's unclear why, but I'm beginning to think something is funky with the DNS config here...

Meantime I'm gonna try a quick CNAME route see if that gives us any more joy. I'll have to come back and clean these up if neither work.