### PR TITLE
LS-2023 Verify sign-in.service.gov.uk with new google DNS code

### DIFF
--- a/domain/domain.template.yml
+++ b/domain/domain.template.yml
@@ -126,7 +126,7 @@ Resources:
         - Name: !Ref Domain
           Type: TXT
           ResourceRecords:
-          - "\"google-site-verification=29R-qq6QJ-1kNjZl5HDOxwbQkPihE3Xs7nbRwa9FdGY\"" # Added for Huw's Google Search Console setup.
+          - "\"google-site-verification=-ZSO6B4ABOUrk09YZd9y3-Gv4MgX0tdrQXHtNjQoLi8\"" # Added for Huw's Google Search Console setup.
           TTL: 3600 # 1hr
 
         # Docs delegated to di-documentation #203073707786


### PR DESCRIPTION
Woop, worked out why (#36) wasn't working. There was a typo in the google console value, we were trying to verify ownership of `sign-in.sevice.gov.uk` which does not exist.

I've generated a new property which generates a new code, so backfilling that. Should be able to get it verified now.