### PR TITLE
BAU: Add DMARC holding record to sign-in.service.gov.uk

### DIFF
--- a/domain/domain.template.yml
+++ b/domain/domain.template.yml
@@ -129,6 +129,11 @@ Resources:
           - "\"google-site-verification=29R-qq6QJ-1kNjZl5HDOxwbQkPihE3Xs7nbRwa9FdGY\"" # Added for Huw's Google Search Console setup.
           TTL: 3600 # 1hr
 
+        - Name: !Sub _dmarc.${Domain}
+          Type: TXT
+          ResourceRecords: ["\"v=DMARC1; p=none; rua=mailto:dmarc-rua@dmarc.service.gov.uk\""]
+          TTL: 3600
+
         # Docs delegated to di-documentation #203073707786
         - Name: !Sub docs.${Domain}
           ResourceRecords: [


### PR DESCRIPTION
NB: Similar example from main DNS records[1]

If you dig sign-in.service.gov.uk we're seeing an absence of a DMARC record, this isn't great, we don't want folks spoofing this domain, even if other One Login Domains are covered.

See:
https://www.ncsc.gov.uk/collection/email-security-and-anti-spoofing/implement-a-dmarc-policy-of-none

We're adding a record here configured to DMARC policy of `none`. The aim is to start monitoring attempts to send emails. Breakdown is as follows for anyone new to DMARC

v=DMARC1; <- Version of DMARC we're talking about, see[2]
p=none;   <- We're setting the policy to none here
rua=mailto:dmarc-rua@dmarc.service.gov.uk <- reporting mailbox

That should do initial config for monitoring

[1]: https://github.com/govuk-one-login/domains/blob/08ba2c2cda8f794be01c216fae7e25b2ecb3f27c/cloudformation/domain/template.yaml#L524C1-L530C16
[2]: https://datatracker.ietf.org/doc/html/rfc7489