### PR TITLE
BAU: give github deployer role permission to tag dynamo

### DIFF
--- a/dev-gha-role/deployment-config.template.yml
+++ b/dev-gha-role/deployment-config.template.yml
@@ -677,6 +677,7 @@ Resources:
               - dynamodb:DeleteTable
               - dynamodb:UpdateContinuousBackups
               - dynamodb:DescribeContinuousBackups
+              - dynamodb:TagResource
 
           - Effect: Allow
             Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${PreviewStacksPrefix}-*-sessions


### PR DESCRIPTION
We want accurate tagging to monitor the cost of preview environments

Seen in cloudformation: 
```
Encountered a permissions error performing a tagging operation, please add required tag permissions.
 Retrying request without including tags. See https://repost.aws/knowledge-center/cloudformation-tagging-permission-error for how to resolve. Resource handler returned message: 
"User: arn:aws:sts::494650018671:assumed-role/deployment-config-GitHubActionsRole-39A6HH0MVI7M/GitHubActions is not authorized to perform: dynamodb:TagResource on resource: 
arn:aws:dynamodb:eu-west-2:494650018671:table/preview-bau-dependabot-data because no identity-based policy allows the dynamodb:TagResource action 
(Service: DynamoDb, Status Code: 400, Request ID: K7GNI47BV2J2TQ2CCHSD9ORJNRVV4KQNSO5AEMVJF66Q9ASUAAJG)" | -
-- | --

```
