### PR TITLE
SSE-3344: Moved update-default-sg.sh script to infra repo.

### DIFF
--- a/aws-account-config/security-groups/update-default-sg.sh
+++ b/aws-account-config/security-groups/update-default-sg.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# This script will update the default security groups to remove ingress and egress from the default subnets.
+
+# shellcheck disable=SC2086
+networkConfigVpcId=$(aws ec2 describe-vpcs --query "Vpcs[*].[VpcId]" --output text --filters "Name=cidr,Values=10.0.0.0/16")
+networkConfigSGId=$(aws ec2 describe-security-groups --query "SecurityGroups[*].[GroupId]" --output text --filters Name=group-name,Values=default Name=vpc-id,Values=$networkConfigVpcId Name=description,Values='default VPC security group')
+
+# Removing inbound rules for default security group
+aws ec2 revoke-security-group-ingress --group-id $networkConfigSGId --protocol -1 --source-group $networkConfigSGId --output text
+
+# Removing outbound rules for default security group
+SGRuleId=$(aws ec2 describe-security-group-rules --filters Name="group-id",Values=$networkConfigSGId --query "SecurityGroupRules[*].[SecurityGroupRuleId]" --output text)
+aws ec2 revoke-security-group-egress --group-id $networkConfigSGId --security-group-rule-ids $SGRuleId --output text


### PR DESCRIPTION
This is mainly needed to protect ingress and egress because all of our development builds are open to the public internet.