### PR TITLE
SSE-3443: Removed non-production sites from the public internet.

### DIFF
--- a/aws-account-config/network/network.template.yml
+++ b/aws-account-config/network/network.template.yml
@@ -134,6 +134,14 @@ Outputs:
     Value: !Join [ ",", !Ref InternetSubnets ]
     Export:
       Name: !Sub ${ExportPrefix}VPC-InternetSubnets
+  SubnetAEIP:
+    Value: !GetAtt VPC.Outputs.NatGatewayZoneAEIP
+    Export:
+      Name: !Sub ${ExportPrefix}VPC-AEIP
+  SubnetBEIP:
+    Value: !GetAtt VPC.Outputs.NatGatewayZoneBEIP
+    Export:
+      Name: !Sub ${ExportPrefix}VPC-BEIP
   ExecuteAPIGatewayVPCEndpointID:
     Value: !GetAtt VPC.Outputs.ExecuteApiGatewayVpcEndpointId
     Export:

--- a/waf/README.md
+++ b/waf/README.md
@@ -25,14 +25,15 @@ Please also run checkov against the template to ensure that you're as secure as 
 ## Deploy
 
 This component should be deployed for the appropriate application (set `$APPLICATION` to `self-service` or `product-pages`), with:
-
+onboarding-infrastructure-waf-product-pages-    
+development
 ```
 export APPLICATION='product-pages'
-export ENVIRONMENT='development'
+export ENVIRONMENT='build'
 ./scripts/deploy-sam-stack.sh \
     --account $ENVIRONMENT \
     --build \
-    --stack-name onboarding-infrastructure-waf-$APPLICATION \
+    --stack-name onboarding-infrastructure-waf-"$APPLICATION"-"$ENVIRONMENT" \
     --template waf/waf.template.yml \
     --manifest waf/package.json \
     --parameters Environment="$ENVIRONMENT" Application="$APPLICATION" \

--- a/waf/waf.template.yml
+++ b/waf/waf.template.yml
@@ -157,10 +157,7 @@ Resources:
               VendorName: AWS
               Name: AWSManagedRulesLinuxRuleSet
           OverrideAction:
-            !If
-            - IsProdLikeEnvironment
-            - Count: { }
-            - None: { }
+            None: { }
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
@@ -173,10 +170,7 @@ Resources:
               VendorName: AWS
               Name: AWSManagedRulesUnixRuleSet
           OverrideAction:
-            !If
-            - IsProdLikeEnvironment
-            - Count: { }
-            - None: { }
+            None: { }
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
@@ -195,7 +189,7 @@ Resources:
             SampledRequestsEnabled: FALSE
 
         - Name: TestRunner-IpList # Allowed in non-production
-          Priority: 30
+          Priority: 31
           Statement:
             IPSetReferenceStatement:
               Arn: !GetAtt Wafv2TestRunnerIpSet.Arn
@@ -290,8 +284,12 @@ Resources:
     Type: AWS::WAFv2::IPSet
     Properties:
       Addresses:
-        - "13.41.232.254"
-        - "3.11.188.14"
+        - !Sub
+          - "${IP}/32"
+          - IP: !ImportValue VPC-AEIP
+        - !Sub
+          - "${IP}/32"
+          - IP: !ImportValue VPC-BEIP
       IPAddressVersion: IPV4
       Scope: REGIONAL
       Tags:


### PR DESCRIPTION
This is the proposed update to WAF policy to remove non-production sites from the public internet. It is assumed that the public instances are:
* production
* integration

This has been tested against the development environment for the product pages application.