### PR TITLE
ATO-1232: deploy backup monitoring stack

### DIFF
--- a/support-stacks/deployment-support.template.yml
+++ b/support-stacks/deployment-support.template.yml
@@ -32,6 +32,9 @@ Parameters:
   DeveloperNotificationsEmail:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /self-service/secure-pipelines/developer-notification-email
+  SlackWorkspaceId:
+    Type: String
+    Default: "T8GT9416G"
 
 Mappings:
   Slack:
@@ -76,7 +79,7 @@ Resources:
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/build-notifications/template.yaml
       Parameters:
-        SlackWorkspaceId: T8GT9416G
+        SlackWorkspaceId: !Ref SlackWorkspaceId
         SlackChannelId: !FindInMap [ Slack, Channel, !Ref Environment, { DefaultValue: !FindInMap [ Slack, Channel, default ] } ]
 
   ECRScanningNotifications:

--- a/support-stacks/deployment-support.template.yml
+++ b/support-stacks/deployment-support.template.yml
@@ -82,6 +82,7 @@ Resources:
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/build-notifications/template.yaml
       Parameters:
+        CreateChatbotChannelConfiguration: "False"
         SlackWorkspaceId: !Ref SlackWorkspaceId
         SlackChannelId: !FindInMap [ Slack, Channel, !Ref Environment, { DefaultValue: !FindInMap [ Slack, Channel, default ] } ]
 

--- a/support-stacks/deployment-support.template.yml
+++ b/support-stacks/deployment-support.template.yml
@@ -7,6 +7,9 @@ Parameters:
   TemplateStorageBucket:
     Type: String
     Default: https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com
+  BackupTemplateStorageBucket:
+    Type: String
+    Default: https://backup-template-storage-templatebucket-747f3bzunrod.s3.eu-west-2.amazonaws.com
   ExportNamePrefix:
     Type: String
     Default: secure-pipelines
@@ -111,6 +114,14 @@ Resources:
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/api-gateway-logs/template.yaml
 
+  BackupVaultMonitoring:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub ${BackupTemplateStorageBucket}/backup-vault-monitoring/template.yaml
+      Parameters:
+        Environment: !If [ ProductionAccount, production, "non-prod" ]
+        DeployChatBot: "No"
+  
 Outputs:
   GitHubIdentityProviderARN:
     Condition: InitialProductionAccount

--- a/support-stacks/deployment-support.template.yml
+++ b/support-stacks/deployment-support.template.yml
@@ -44,8 +44,8 @@ Mappings:
 
 Conditions:
   InitialAccount: !Equals [ !Ref InitialAccount, Yes ]
-  DevelopmentAccount: !Equals [ !Ref Environment, development ]
-  InitialProductionAccount: !And [ !Condition InitialAccount, !Not [ !Condition DevelopmentAccount ] ]
+  ProductionAccount: !Not [ !Equals [ !Ref Environment, development ] ]
+  InitialProductionAccount: !And [ !Condition InitialAccount, !Condition ProductionAccount ]
 
 Resources:
   GitHubIdentityProvider:

--- a/support-stacks/deployment-support.template.yml
+++ b/support-stacks/deployment-support.template.yml
@@ -123,6 +123,39 @@ Resources:
         Environment: !If [ ProductionAccount, production, "non-prod" ]
         DeployChatBot: "No"
   
+  ChatbotRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: "chatbot.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+      Tags:
+        - Key: Name
+          Value: !Join
+            - "-"
+            - - !Ref AWS::StackName
+              - "ChatbotRole"
+        - Key: Service
+          Value: "ci/cd"
+        - Key: Source
+          Value: "govuk-one-login/govuk-one-login/onboarding-self-service-infra/support-stacks/deployment-support.template.yml"
+
+  ChatbotChannelConfiguration:
+    Type: AWS::Chatbot::SlackChannelConfiguration
+    Properties:
+      ConfigurationName: !Sub "${AWS::StackName}-chatbot"
+      IamRoleArn: !GetAtt ChatbotRole.Arn
+      SlackWorkspaceId: !Ref SlackWorkspaceId
+      SlackChannelId: !FindInMap [ Slack, Channel, !Ref Environment, { DefaultValue: !FindInMap [ Slack, Channel, default ] } ]
+      SnsTopicArns:
+        - !GetAtt SlackNotifications.Outputs.BuildNotificationTopicArn
+        - !GetAtt BackupVaultMonitoring.Outputs.BackupNotificationTopicARN
+
 Outputs:
   GitHubIdentityProviderARN:
     Condition: InitialProductionAccount


### PR DESCRIPTION
Deploy the 'backup-monitoring' stack for SSE.

Messages to be posted in the same Slack channels (`#di-sse-dev-notifications` and `#di-sse-tech-notifications`) as the build notifications. AWS does not allow two chatbot resources with the same workspace and channel ID and so the creation of the chatbot resource has been extracted from the "build notifications" stack into this support stack. The chatbot resource is then subscribed to both topics (build and backup).

Successfully deployed to the onboarding dev env using the deployment shell script in the same directory as the modified file. Slack integration working as expected (see `#di-sse-dev-notifications` 11/03/25 16:48).

Note that manual removal of the existing chatbot resource (for build notifications) was required.