### PR TITLE
ATO-1483: upgrade node runtime from 18 to 22

### DIFF
--- a/monitoring/alert-notifications/alert-notifications.template.yml
+++ b/monitoring/alert-notifications/alert-notifications.template.yml
@@ -66,7 +66,7 @@ Resources:
       Description: A lambda function that takes an SNS message and sends it to Slack
       CodeUri: src
       Handler: sns-to-slack.lambdaHandler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       LoggingConfig:
         LogGroup: !Ref LambdaLogsGroup
       Environment:

--- a/monitoring/smoke-tests/smoke-tests.template.yml
+++ b/monitoring/smoke-tests/smoke-tests.template.yml
@@ -68,7 +68,7 @@ Resources:
       Description: A lambda function that takes a Canary SNS message and sends it as an alert notification
       CodeUri: src
       Handler: send-alert.lambdaHandler
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       LoggingConfig:
         LogGroup: !Ref LambdaLogsGroup
       Environment:


### PR DESCRIPTION
The node runtimes in this repo need updating to v22.

Note that the canary alarm runtimes (`syn-nodejs-puppeteer-6.2` at present) are to be updated under ATO-1527.

Checked the rest of the repo for `nodejs` runtimes - couldn't see any.

## Testing

Deployed and tested on the dev environment, tested the two lambdas whose runtimes have updated:
- `CanarySnsNotificationFunction`
  - Publishes to the SNS topic with `AlertNotificationsSnsTopic` in the name - consumed by the `SnsToSlackFunction` function below.
  - Tested by publishing the following event to the SNS topic with `CanarySnsTopic` in the name: 
    ```json
    {
        "AlarmName": "ATO-1483_test-sse-CanarySnsNotificationFunction-lambda-runtime-upgrade",
        "NewStateValue": "OK",
        "OldStateValue": "test"
    }
    ```
  - See the associated notification in the `#di-sse-alerts-test` Slack channel 12/03/25 11:43
- `SnsToSlackFunction`
  - Sends a notification to the slack channel defined in the `SLACK_CHANNEL` env var - set to `di-sse-alerts-test` on the dev env
  - Tested by publishing the following event to the SNS topic with `AlertNotificationsSnsTopic` in the name: 
    ```json
    {
        "Application": "SSE",
        "Heading": "ATO-1483: Test of SSE SnsToSlackFunction lambda runtime upgrade",
        "Message": "ATO-1483: Test **message** with some `markdown`",
        "Context": "Test **context** with some `markdown`",
        "Colour": "Green"
    }
    ```
  - See the associated notification in the `#di-sse-alerts-test` Slack channel 12/03/25 11:41