### PR TITLE
ATO-1723: Add new DSIT IP to WAF

### DIFF
--- a/waf/waf.template.yml
+++ b/waf/waf.template.yml
@@ -283,6 +283,7 @@ Resources:
         - "217.196.229.81/32"
         - "51.149.8.0/25"
         - "51.149.8.128/29"
+        - "3.9.56.99/32"
       IPAddressVersion: IPV4
       Scope: REGIONAL
       Tags:


### PR DESCRIPTION
Although this WAF is most not used due to the change to FMS, note that it still covers Cognito and so we still need to support it