### PR TITLE
BAU: Bump pupeteer version

### DIFF
--- a/monitoring/smoke-tests/canary-alarms.template.yml
+++ b/monitoring/smoke-tests/canary-alarms.template.yml
@@ -170,7 +170,7 @@ Resources:
       ExecutionRoleArn:
         Fn::ImportValue:
           !Sub "${SmokeStack}-canary-role"
-      RuntimeVersion: syn-nodejs-puppeteer-6.2
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       RunConfig:
         TimeoutInSeconds: 60
       Schedule:
@@ -340,7 +340,7 @@ Resources:
       ExecutionRoleArn:
         Fn::ImportValue:
           !Sub "${SmokeStack}-canary-role"
-      RuntimeVersion: syn-nodejs-puppeteer-6.2
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       RunConfig:
         TimeoutInSeconds: 60
       Schedule:


### PR DESCRIPTION
Under the hood this uses node, and the old version was using node 18 which is deprecated. This uses node 20.