### PR TITLE
ATO-1886: remove checkov

### DIFF
--- a/support-stacks/README.md
+++ b/support-stacks/README.md
@@ -1,0 +1,14 @@
+## Deployments
+
+Sign into the account you want to deploy to
+export AWS_PROFILE=account-profile
+aws sso login
+
+If unsure of account profiles, run aws configure list-profiles
+
+Make sure you have gh installed and have logged in through gh auth login
+Note: this github step does not currently work as only an admin can update the github action
+
+And run deploy-support-stacks.sh
+
+Note: merging into main will not automatically deploy changes.

--- a/support-stacks/deployment-support.template.yml
+++ b/support-stacks/deployment-support.template.yml
@@ -98,13 +98,6 @@ Resources:
     Properties:
       TemplateURL: !Sub ${TemplateStorageBucket}/lambda-audit-hook/template.yaml
 
-  CheckovHook:
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      TemplateURL: !Sub ${TemplateStorageBucket}/checkov-hook/template.yaml
-      Parameters:
-        FailureMode: WARN
-
   InfrastructureAuditHook:
     Type: AWS::CloudFormation::Stack
     Properties:


### PR DESCRIPTION
This dev platform checkov hook stack is deprecated and so can no longer be used.

This script has been successfully ran against dev, it needs to be ran against other envs when merged.