### PR TITLE
ATO-2308: Use AWS managed key for SSE not CMK

### DIFF
--- a/aws-account-config/network/network.template.yml
+++ b/aws-account-config/network/network.template.yml
@@ -102,18 +102,20 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: 'aws:kms'
-              KMSMasterKeyID: !GetAtt AccessLogsBucketKey.Arn
 
-  AccessLogsBucketKeyAlias:
-    Type: AWS::KMS::Alias
-    Properties:
-      AliasName: alias/accessLogsBucketKey
-      TargetKeyId: !Ref AccessLogsBucketKey
-
+  # We are keeping this key around as previously we used 
+  # it to encrypt the ALB access logs in the S3 bucket.
+  # AWS say that they only support S3 Managed keys for 
+  # encryption. To ensure we can continue to decrypt 
+  # previously written logs we can retain this key
+  # but switch back to using an S3 Managed key
   AccessLogsBucketKey:
     Type: AWS::KMS::Key
     Properties:
-      Description: Key used to encrypt the access logs bucket
+      Description: |
+        DEPRECATED - was previously used as the AccessLogsBucket encryption key, however
+        ALB access log buckets only support S3 Managed encryption keys, not customer managed
+        ones. This key is retained in case we need to decrypt historical logs
       EnableKeyRotation: true
       KeyPolicy:
         Version: 2012-10-17


### PR DESCRIPTION
This bucket is used for our application load balancer logs and currently has a CMK assigned for encryption.

The AWS docs[1] state that a bucket for ALB access logs must use AWS S3 managed encryption keys. So we can remove the customer managed key here - which will default to using the AWS S3 managed key instead. This didn't create an issue until I tried deploying a dev branch to product pages, which created a new ALB and errored when setting up the Access Log configuration. I assume this has not been seen in other envs (which are writing access logs successfully) because subsequent deployments have not modified this configuration.

I tested this by:
- Deploying to dev 
- Checked the bucket - it is now using S3 managed key instead of a CMK
- Re-ran the deploy workflow 
- Saw it deployed successfully

[1] - https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#:~:text=The%20only%20server%2Dside%20encryption%20option%20that%27s%20supported%20is%20Amazon%20S3%2Dmanaged%20keys%20(SSE%2DS3).%20For%20more%20information%2C%20see%20Amazon%20S3%2Dmanaged%20encryption%20keys%20(SSE%2DS3).