### PR TITLE
ATO-2543: Bump synthetics to v15.1

### DIFF
--- a/monitoring/smoke-tests/canary-alarms.template.yml
+++ b/monitoring/smoke-tests/canary-alarms.template.yml
@@ -74,10 +74,10 @@ Resources:
         Script: !Sub
           - |
             const { URL } = require('url');
-            const synthetics = require('Synthetics');
-            const log = require('SyntheticsLogger');
+            const synthetics = require('@aws/synthetics-puppeteer');
+            const log = require('@aws/synthetics-logger');
             const syntheticsConfiguration = synthetics.getConfiguration();
-            const syntheticsLogHelper = require('SyntheticsLogHelper');
+            const syntheticsLogHelper = require('@aws/synthetics-log-helper');
             
             const loadBlueprint = async function () {
             
@@ -184,7 +184,7 @@ Resources:
       ExecutionRoleArn:
         Fn::ImportValue:
           !Sub "${SmokeStack}-canary-role"
-      RuntimeVersion: syn-nodejs-puppeteer-10.0
+      RuntimeVersion: syn-nodejs-puppeteer-15.1
       RunConfig:
         TimeoutInSeconds: 60
       Schedule:
@@ -249,10 +249,10 @@ Resources:
         Script: !Sub
           - |
             const { URL } = require('url');
-            const synthetics = require('Synthetics');
-            const log = require('SyntheticsLogger');
+            const synthetics = require('@aws/synthetics-puppeteer');
+            const log = require('@aws/synthetics-logger');
             const syntheticsConfiguration = synthetics.getConfiguration();
-            const syntheticsLogHelper = require('SyntheticsLogHelper');
+            const syntheticsLogHelper = require('@aws/synthetics-log-helper');
             
             const loadBlueprint = async function () {
             
@@ -359,7 +359,7 @@ Resources:
       ExecutionRoleArn:
         Fn::ImportValue:
           !Sub "${SmokeStack}-canary-role"
-      RuntimeVersion: syn-nodejs-puppeteer-10.0
+      RuntimeVersion: syn-nodejs-puppeteer-15.1
       RunConfig:
         TimeoutInSeconds: 60
       Schedule:


### PR DESCRIPTION
Following the migration guide [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Library_nodejs_puppeteer.html#CloudWatch_Synthetics_runtimeversion-nodejs-puppeteer-15.0) 

The only thing that needed updating was imports.

Deployed to dev and saw the canaries were running ok and reporting the correct synthetics version

Will deploy to remaining envs after merge!