### PR TITLE
Prove domain ownership to NCSC VMS

### DIFF
--- a/domain/domain.template.yml
+++ b/domain/domain.template.yml
@@ -127,6 +127,7 @@ Resources:
           Type: TXT
           ResourceRecords:
           - "\"google-site-verification=-ZSO6B4ABOUrk09YZd9y3-Gv4MgX0tdrQXHtNjQoLi8\"" # Added for Huw's Google Search Console setup.
+          - "\"asvdns_97e2ed1d-da05-4446-919b-27a006fe519a\"" # PSREDEV-3533 - NCSC Vulnerability Management Service
           TTL: 3600 # 1hr
 
         # Docs delegated to di-documentation #203073707786


### PR DESCRIPTION
As part of the migration from NCSC WebCheck to the new vulnerability monitoring service, we need to prove domain ownership with a TXT record.  This is that record.